### PR TITLE
fix: MoveOperation path comparisons

### DIFF
--- a/src/JsonPatch/Adaptors/JsonNetTargetAdapter.cs
+++ b/src/JsonPatch/Adaptors/JsonNetTargetAdapter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using JsonPatch.Operations;
 using JsonPatch.Operations.Abstractions;
 using Newtonsoft.Json.Linq;
@@ -135,7 +136,7 @@ namespace JsonPatch.Adaptors
 
         protected override void Move(MoveOperation operation)
         {
-            if (operation.Path.ToString().StartsWith(operation.FromPath.ToString()))
+            if (operation.FromPath.Tokens.Zip(operation.Path.Tokens, (a, b) => a.Equals(b)).Aggregate(true, (acc, v) => acc && v))
                 throw new ArgumentException("To path cannot be below from path");
 
             var token = operation.FromPath.Find(_target);

--- a/src/JsonPatchTests/MoveTests.cs
+++ b/src/JsonPatchTests/MoveTests.cs
@@ -44,6 +44,21 @@ namespace JsonPatchTests
             Assert.IsType(typeof(JObject), result);
         }
 
+        [Fact]
+        public void Move_similar_named_paths()
+        {
+            var sample = PatchTests.GetSample2();
 
+            var patchDocument = new PatchDocument();
+            var frompointer = new JsonPointer("/books");
+            var topointer = new JsonPointer("/bookshelf");
+
+            patchDocument.AddOperation(new MoveOperation() { FromPath = frompointer, Path = topointer });
+
+            patchDocument.ApplyTo(sample);
+
+            var result = topointer.Find(sample);
+            Assert.IsType<JArray>(result);
+        }
     }
 }

--- a/src/JsonPatchTests/Operations/MoveOperationTests.cs
+++ b/src/JsonPatchTests/Operations/MoveOperationTests.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using JsonPatch.Operations;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Tavis;
+using Xunit;
+
+namespace JsonPatchTests.Operations
+{
+    public class MoveOperationTests
+    {
+        #region Mocks
+
+        private const string MockBooksTitle0 = "The Great Gatsby";
+        private const string MockBooksAuthor0 = "F. Scott Fitzgerald";
+
+        private const string MockBooksTitle1 = "The Grapes of Wrath";
+        private const string MockBooksAuthor1 = "John Steinbeck";
+
+        private static JToken MockJsonFile()
+        {
+            return JToken.Parse($@"{{
+                'books': [
+                    {{
+                      'title' : '{MockBooksTitle0}',
+                      'author' : '{MockBooksAuthor0}'
+                    }},
+                    {{
+                      'title' : '{MockBooksTitle1}',
+                      'author' : '{MockBooksAuthor1}'
+                    }}
+                ]
+            }}");
+        }
+
+        private static JToken MockPatch()
+        {
+            return JToken.Parse(@"[{
+                'op': 'move',
+                'path': '/bookshelf',
+                'from': '/books'
+            }]");
+        }
+
+        #endregion
+
+        #region Valid Paths
+
+        [Fact]
+        public void ShouldMoveElementToSpecificLocation()
+        {
+            var sample = MockJsonFile();
+            var sut = new MoveOperation
+            {
+                Path = new JsonPointer("/read"),
+                FromPath = new JsonPointer("/books"),
+            };
+
+            var patchDocument = new PatchDocument();
+            patchDocument.AddOperation(sut);
+            patchDocument.ApplyTo(sample);
+
+            var target = sample["read"].ToList();
+            Assert.Equal(2, target.Count);
+
+            var book0 = target[0];
+            Assert.Equal(MockBooksAuthor0, book0["author"].ToObject<string>());
+            Assert.Equal(MockBooksTitle0, book0["title"].ToObject<string>());
+
+            var book1 = target[1];
+            Assert.Equal(MockBooksAuthor1, book1["author"].ToObject<string>());
+            Assert.Equal(MockBooksTitle1, book1["title"].ToObject<string>());
+        }
+
+        [Fact]
+        public void ShouldAddElementAtSpecificLocation_WhenIndexIsExplicitlyProvided()
+        {
+            var sample = MockJsonFile();
+            var sut = new MoveOperation
+            {
+                Path = new JsonPointer("/read"),
+                FromPath = new JsonPointer("/books/1"),
+            };
+
+            var patchDocument = new PatchDocument();
+            patchDocument.AddOperation(sut);
+            patchDocument.ApplyTo(sample);
+
+            var origin = sample["books"];
+            Assert.IsType<JArray>(origin);
+            Assert.Single(origin);
+
+            var book0 = origin[0];
+            Assert.Equal(MockBooksAuthor0, book0["author"].ToObject<string>());
+            Assert.Equal(MockBooksTitle0, book0["title"].ToObject<string>());
+
+            var book1 = sample["read"];
+            Assert.IsType<JObject>(book1);
+
+            Assert.Equal(MockBooksAuthor1, book1["author"].ToObject<string>());
+            Assert.Equal(MockBooksTitle1, book1["title"].ToObject<string>());
+        }
+
+        [Fact]
+        public void ShouldMoveElementToSpecificLocation_PathSubstringsAreFine()
+        {
+            var sample = MockJsonFile();
+            var sut = new MoveOperation
+            {
+                Path = new JsonPointer("/bookshelf"),
+                FromPath = new JsonPointer("/books"),
+            };
+
+            var patchDocument = new PatchDocument();
+            patchDocument.AddOperation(sut);
+            patchDocument.ApplyTo(sample);
+
+            var target = sample["bookshelf"].ToList();
+            Assert.Equal(2, target.Count);
+
+            var book0 = target[0];
+            Assert.Equal(MockBooksAuthor0, book0["author"].ToObject<string>());
+            Assert.Equal(MockBooksTitle0, book0["title"].ToObject<string>());
+
+            var book1 = target[1];
+            Assert.Equal(MockBooksAuthor1, book1["author"].ToObject<string>());
+            Assert.Equal(MockBooksTitle1, book1["title"].ToObject<string>());
+
+        }
+
+        #endregion
+
+        #region Invalid Paths
+
+        [Fact]
+        public void ShouldThrowInvalidOperationException_WhenPathDoesnotExisit()
+        {
+            var sample = MockJsonFile();
+            var sut = new MoveOperation
+            {
+                Path = new JsonPointer("/temp/1"),
+                FromPath = new JsonPointer("/books/invalid")
+            };
+
+            var patchDocument = new PatchDocument();
+            patchDocument.AddOperation(sut);
+
+            Assert.Throws<Tavis.PathNotFoundException>(() =>
+            {
+                patchDocument.ApplyTo(sample);
+            });
+        }
+
+        [Fact]
+        public void ShouldThrowArgumentException_WhenPathIsASubPathOfFromPath()
+        {
+            var sample = MockJsonFile();
+            var sut = new MoveOperation
+            {
+                Path = new JsonPointer("/books/finished"),
+                FromPath = new JsonPointer("/books")
+            };
+
+            var patchDocument = new PatchDocument();
+            patchDocument.AddOperation(sut);
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                patchDocument.ApplyTo(sample);
+            });
+        }
+
+        #endregion
+
+        #region Serialzation
+
+        [Fact]
+        public void ShouldProduceMovePatch()
+        {
+            // Arrange
+            var expected = MockPatch().ToString(Formatting.Indented);
+            var patchDocument = new PatchDocument();
+            var sut = new MoveOperation
+            {
+                Path = new JsonPointer("/bookshelf"),
+                FromPath = new JsonPointer("/books")
+            };
+
+            // Act
+            patchDocument.AddOperation(sut);
+            var stream = patchDocument.ToStream();
+            var reader = new StreamReader(stream);
+
+            // Assert
+            var actual = reader.ReadToEnd();
+            Assert.Equal(expected, actual);
+
+            // Teardown
+            reader.Dispose();
+            stream.Dispose();
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
This commit fixes a defect in the MoveOperation's path comparisons for trees belonging to the same root. Comparisons are now done on each path element, individually, with the destination's elements; properly determining if it's a subtree or not.

This is now a valid patch:
```
[
     { "op": "move", "from": "/a/b/c", "path": "/a/b/cdefg" }
]
```